### PR TITLE
NS-1412 revise cache key strategy

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -110,8 +110,7 @@ module CachedResource
 
       # Generate the request cache key.
       def cache_key(*arguments)
-        key = "#{name.parameterize.gsub("-", "/")}/#{arguments.join('/')}".downcase.delete(' ')
-        Digest::MD5.hexdigest(key)
+        key_from_url(url_from_parameters(arguments.first))
       end
 
       # Make a full duplicate of an ActiveResource record.
@@ -120,6 +119,50 @@ module CachedResource
         record.dup.tap do |o|
           o.instance_variable_set(:@persisted, record.persisted?)
         end
+      end
+
+      private
+
+      Url = Struct.new(:url) do
+        def parts
+          url
+            .split('?')
+            .map{ |part| part.gsub(/\.json/, '') }
+        end
+
+        def path
+          parts[0]
+        end
+
+        def query
+          parts[1]
+        end
+
+        def size
+          parts.size
+        end
+      end
+
+      def key_from_url(url)
+        if url.query
+          url.path + '#' + Digest::MD5.hexdigest(url.query)
+        else
+          url.path
+        end
+      end
+
+      def url_from_parameters(parameters)
+        if includes_from_parameter?(parameters)
+          Url.new(parameters.second[:from])
+        else
+          Url.new(element_path(*parameters))
+        end
+      end
+
+      def includes_from_parameter?(parameters)
+        parameters.second &&
+        parameters.second.is_a?(Hash) &&
+        parameters.second.include?(:from)
       end
 
     end


### PR DESCRIPTION
This commit updates the cache key strategy in order to facilitate
clearing portions of the cache and decouple the cache clear strategy
from code in d360 that accesses the cache. Because api urls were
transformed into a MD5 hashs, the cache key task would be required
to rebuild all possible combiniations of path and query parameters
in order to invalidation a portion of the cache. The new solution
retains the url path and only hashes the parameters. Thus, all keys
matching a path can be simultaneously invalidated without knowing
the query parameters. Now the cache clear task will no longer need
to be updated as additional parameters are added to the api or
the usage of parameters changes in d360.