### PR TITLE
NS-1412: address explicit params and truncation

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -134,6 +134,10 @@ module CachedResource
           parts[0]
         end
 
+        def truncated_path
+          path.truncate(150)
+        end
+
         def query
           parts[1]
         end
@@ -145,15 +149,18 @@ module CachedResource
 
       def key_from_url(url)
         if url.query
-          url.path + '#' + Digest::MD5.hexdigest(url.query)
+          url.truncated_path + '#' + Digest::MD5.hexdigest(url.query)
         else
-          url.path
+          url.truncated_path
         end
       end
 
       def url_from_parameters(parameters)
-        if includes_from_parameter?(parameters)
+        case
+        when includes_from_parameter?(parameters)
           Url.new(parameters.second[:from])
+        when includes_params_parameter?(parameters)
+          Url.new(element_path(parameters.first, parameters.second[:params]))
         else
           Url.new(element_path(*parameters))
         end
@@ -163,6 +170,12 @@ module CachedResource
         parameters.second &&
         parameters.second.is_a?(Hash) &&
         parameters.second.include?(:from)
+      end
+
+      def includes_params_parameter?(parameters)
+        parameters.second &&
+        parameters.second.is_a?(Hash) &&
+        parameters.second.include?(:params)
       end
 
     end


### PR DESCRIPTION
This commit updates the key generation strategy to handle the cases
where the :params option is supplied to ActiveResource, such as
it is used in nsight to access core-api V2 endpoints. It also
limits the path length to 150 characters so as to avoid exceeding
the FileStore file name length limits that could potentially occur
for very long endpoints.