### PR TITLE
NS-1412: address case with both from and params

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -157,6 +157,8 @@ module CachedResource
 
       def url_from_parameters(parameters)
         case
+        when includes_both_parameters?(parameters)
+          Url.new("#{parameters.second[:from]}?#{parameters.second[:params].to_query}")
         when includes_from_parameter?(parameters)
           Url.new(parameters.second[:from])
         when includes_params_parameter?(parameters)
@@ -176,6 +178,11 @@ module CachedResource
         parameters.second &&
         parameters.second.is_a?(Hash) &&
         parameters.second.include?(:params)
+      end
+
+      def includes_both_parameters?(parameters)
+        includes_from_parameter?(parameters) &&
+        includes_params_parameter?(parameters)
       end
 
     end


### PR DESCRIPTION
In some cases, both from and params parameters are being
used in active resource calls. This commit handles that
edge case where both are provided.